### PR TITLE
Simplify and improve `lookup` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,12 +244,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
 ]
 
 [[package]]
@@ -355,6 +379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +452,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,7 +512,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
  "windows-sys",
 ]
 
@@ -694,6 +743,20 @@ dependencies = [
  "log",
  "serde",
  "teamsearch_utils",
+ "tempfile",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.0.3",
+ "windows-sys",
 ]
 
 [[package]]
@@ -702,7 +765,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "windows-sys",
 ]
 
@@ -774,6 +837,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -866,3 +938,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ path-absolutize = "3.1.1"
 rayon = "1.5.1"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = { version = "1.0.113" }
+tempfile = "3.8"
 thin-vec = "0.2.13"
 wild = { version = "2" }
 

--- a/crates/teamsearch/src/commands/lookup.rs
+++ b/crates/teamsearch/src/commands/lookup.rs
@@ -11,7 +11,7 @@ use teamsearch_workspace::{codeowners::CodeOwners, settings::Settings};
 #[derive(Serialize)]
 pub(crate) struct LookupEntry {
     /// The owner of the file, if any.
-    pub(crate) team: Option<String>,
+    pub(crate) teams: Vec<String>,
 
     /// The path of the entry.
     pub(crate) path: PathBuf,
@@ -43,7 +43,7 @@ pub fn lookup(files: &[PathBuf], settings: Settings) -> Result<LookupResult> {
 
     // For each path (other than last), we need to find the team that owns it.
     for path in paths.iter().take(paths.len() - 1) {
-        entries.push(LookupEntry { path: path.clone(), team: codeowners.lookup(path) });
+        entries.push(LookupEntry { path: path.clone(), teams: codeowners.lookup(path) });
     }
 
     Ok(LookupResult { entries })

--- a/crates/teamsearch/src/commands/orphans.rs
+++ b/crates/teamsearch/src/commands/orphans.rs
@@ -60,11 +60,14 @@ pub fn orphans(
             // For a small number of files, there no need to use a thread pool.
             let pool = thread_pool::construct_thread_pool();
             pool.install(|| {
-                all_files.par_iter().filter(|file| !codeowners.is_owned(file.path())).cloned().collect()
+                all_files
+                    .par_iter()
+                    .filter(|file| !codeowners.is_owned(file.path()))
+                    .cloned()
+                    .collect()
             })
         }
     };
-
 
     Ok(OrphanResult { orphans })
 }

--- a/crates/teamsearch/src/lib.rs
+++ b/crates/teamsearch/src/lib.rs
@@ -163,8 +163,16 @@ fn lookup(args: LookupCommand) -> Result<ExitStatus> {
         // Print out the results in JSON format.
         println!("{}", serde_json::to_string_pretty(&results)?);
     } else {
-        for LookupEntry { path, team } in results.entries {
-            info!("{}: {}", path.display(), team.as_ref().map_or("none", |t| t.as_str()))
+        for LookupEntry { path, teams } in results.entries {
+            //
+            if teams.is_empty() {
+                info!("{}: none", path.display());
+                continue;
+            }
+
+            for team in teams {
+                info!("{}: {}", path.display(), team)
+            }
         }
     }
 

--- a/crates/teamsearch_workspace/Cargo.toml
+++ b/crates/teamsearch_workspace/Cargo.toml
@@ -15,3 +15,7 @@ index_vec = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
+
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/teamsearch_workspace/src/codeowners.rs
+++ b/crates/teamsearch_workspace/src/codeowners.rs
@@ -1,11 +1,13 @@
 //! Implementation and utilities for dealing with the `CODEOWNERS
 //! file format.
 
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Result;
 use derive_more::Constructor;
-use teamsearch_utils::fs;
 
 use crate::settings::{FilePattern, FilePatternSet};
 
@@ -16,6 +18,9 @@ pub struct CodeOwners {
 
     /// A pre-computed matcher for the owner.
     owner_set: FilePatternSet,
+
+    /// The root directory of the repository.
+    root: PathBuf,
 
     /// Generally ignored paths.
     pub ignored_patterns: Vec<FilePattern>,
@@ -33,45 +38,32 @@ impl CodeOwners {
     }
 
     /// Check if a file is owned by a team.
-    pub fn is_owned_by(&self, path: &PathBuf, team: &str) -> bool {
-        let path = fs::normalize_path(path);
+    pub fn is_owned_by(&self, path: &Path, team: &str) -> bool {
         let set = self.get_pattern_for_team(team);
 
-        // @@Hack: Check if we're missing a `/` at the end of the path.
-        let path_pat = if path.is_dir() && !path.to_string_lossy().ends_with('/') {
-            path.to_string_lossy().to_string() + "/"
-        } else {
-            path.to_string_lossy().to_string()
-        };
-
+        // Get path relative to root if possible
+        let relative_path = self.get_relative_path(path);
+        let path_pat = self.format_path_for_matching(&relative_path);
         set.is_match(&path_pat)
     }
 
     /// Check if a file is owned by anyone.
-    pub fn is_owned(&self, path: &PathBuf) -> bool {
-        // @@Hack: Check if we're missing a `/` at the end of the path.
-        if path.is_dir() && !path.to_string_lossy().ends_with('/') {
-            let pat = path.to_string_lossy().to_string() + "/";
-            self.owner_set.is_match(&pat)
-        } else {
-            self.owner_set.is_match(path)
-        }
+    pub fn is_owned(&self, path: &Path) -> bool {
+        let relative_path = self.get_relative_path(path);
+        let path_pat = self.format_path_for_matching(&relative_path);
+
+        self.owner_set.is_match(&path_pat)
     }
 
     /// Lookup a file path to see which team owns it.
-    /// 
+    ///
     /// @@Future: we need to expand this so it supports multiple teams.
     /// The order should be based on the order of the teams in the CODEOWNERS
     /// file.
-    pub fn lookup(&self, path: &PathBuf) -> Option<String> {
-        let path = fs::normalize_path(path);
+    pub fn lookup(&self, path: &Path) -> Vec<String> {
+        let path = self.get_relative_path(path);
+        let path_pat = self.format_path_for_matching(&path);
 
-        // @@Hack: Check if we're missing a `/` at the end of the path.
-        let path_pat = if path.is_dir() && !path.to_string_lossy().ends_with('/') {
-            path.to_string_lossy().to_string() + "/"
-        } else {
-            path.to_string_lossy().to_string()
-        };
         let mut owners = vec![];
 
         for owner in self.owners.keys() {
@@ -85,6 +77,37 @@ impl CodeOwners {
         }
 
         owners
+    }
+
+    /// Helper method to get a path relative to the root
+    fn get_relative_path(&self, path: &Path) -> PathBuf {
+        if path.starts_with(&self.root) {
+            path.strip_prefix(&self.root).unwrap_or(path).to_path_buf()
+        } else {
+            path.to_path_buf()
+        }
+    }
+
+    /// Helper method to format path for matching, ensuring directories end with
+    /// "/"
+    /// Helper method to format path for matching
+    /// - Ensures directories end with "/"
+    /// - Ensures paths start with "/"
+    fn format_path_for_matching(&self, path: &Path) -> String {
+        // Convert path to string
+        let mut path_str = path.to_string_lossy().to_string();
+
+        // Ensure directories end with "/"
+        if path.is_dir() && !path_str.ends_with('/') {
+            path_str = format!("{}/", path_str);
+        }
+
+        // Ensure paths start with "/"
+        if !path_str.starts_with('/') {
+            path_str = format!("/{}", path_str);
+        }
+
+        path_str
     }
 
     /// Get all patterns for a specific team.
@@ -122,12 +145,12 @@ impl CodeOwners {
     ///
     /// /docs/ @another-team @some-team
     /// ```
-    pub fn parse_from_file(path: &PathBuf, root: &PathBuf) -> Result<Self, anyhow::Error> {
+    pub fn parse_from_file(path: &PathBuf, root: &Path) -> Result<Self, anyhow::Error> {
         let contents = std::fs::read_to_string(path).or_else(|_| {
             anyhow::bail!("Failed to read the CODEOWNERS file at {:?}", path);
         })?;
 
-        let mut owners = CodeOwners::default();
+        let mut owners = CodeOwners { root: root.to_path_buf(), ..CodeOwners::default() };
 
         for line in contents.lines() {
             let line = line.trim();
@@ -148,7 +171,7 @@ impl CodeOwners {
                     buf.push_str("**");
                 }
 
-                fs::normalize_path_to(buf, root).to_string_lossy().to_string()
+                buf.to_string()
             };
 
             // If no owners are specified, we consider these to be owned by anyone, and

--- a/crates/teamsearch_workspace/src/codeowners.rs
+++ b/crates/teamsearch_workspace/src/codeowners.rs
@@ -195,3 +195,216 @@ impl CodeOwners {
         Ok(owners)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{self, File},
+        io::Write,
+        path::PathBuf,
+    };
+
+    use tempfile::{TempDir, tempdir};
+
+    use super::*;
+
+    /// Helper function to create a temporary directory with a CODEOWNERS file
+    fn setup_test_dir(codeowners_content: &str) -> (TempDir, PathBuf) {
+        let temp_dir = tempdir().expect("Failed to create temp directory");
+        let codeowners_path = temp_dir.path().join("CODEOWNERS");
+
+        let mut file = File::create(&codeowners_path).expect("Failed to create CODEOWNERS file");
+        file.write_all(codeowners_content.as_bytes()).expect("Failed to write to CODEOWNERS file");
+
+        // Create some directories for testing
+        let src_dir = temp_dir.path().join("src");
+        fs::create_dir(&src_dir).expect("Failed to create src directory");
+
+        let docs_dir = temp_dir.path().join("docs");
+        fs::create_dir(&docs_dir).expect("Failed to create docs directory");
+
+        let tests_dir = temp_dir.path().join("tests");
+        fs::create_dir(&tests_dir).expect("Failed to create tests directory");
+
+        // Create some files for testing
+        File::create(src_dir.join("main.rs")).expect("Failed to create main.rs");
+        File::create(docs_dir.join("README.md")).expect("Failed to create README.md");
+
+        (temp_dir, codeowners_path)
+    }
+
+    #[test]
+    fn test_parse_from_file() {
+        let codeowners_content = r#"
+# This is a comment
+/src/ @dev-team
+/docs/ @docs-team @dev-team
+/tests/ 
+        "#;
+
+        let (temp_dir, codeowners_path) = setup_test_dir(codeowners_content);
+        let root = temp_dir.path().to_path_buf();
+
+        let code_owners = CodeOwners::parse_from_file(&codeowners_path, &root).unwrap();
+
+        // Check if teams exist
+        assert!(code_owners.has_team("@dev-team"));
+        assert!(code_owners.has_team("@docs-team"));
+        assert!(!code_owners.has_team("@non-existent-team"));
+
+        // Check patterns for teams
+        let dev_team_patterns = code_owners.get_patterns_for_team("@dev-team");
+        assert_eq!(dev_team_patterns.len(), 2);
+
+        let docs_team_patterns = code_owners.get_patterns_for_team("@docs-team");
+        assert_eq!(docs_team_patterns.len(), 1);
+
+        // Check ignored patterns
+        let ignored_patterns = code_owners.get_ignored_patterns();
+        assert_eq!(ignored_patterns.len(), 1);
+    }
+
+    #[test]
+    fn test_is_owned_by() {
+        let codeowners_content = r#"
+/src/ @dev-team
+/docs/ @docs-team @dev-team
+/tests/
+        "#;
+
+        let (temp_dir, codeowners_path) = setup_test_dir(codeowners_content);
+        let root = temp_dir.path().to_path_buf();
+
+        let code_owners = CodeOwners::parse_from_file(&codeowners_path, &root).unwrap();
+
+        // Test file ownership
+        assert!(code_owners.is_owned_by(&root.join("src/main.rs"), "@dev-team"));
+        assert!(!code_owners.is_owned_by(&root.join("src/main.rs"), "@docs-team"));
+
+        assert!(code_owners.is_owned_by(&root.join("docs/README.md"), "@docs-team"));
+        assert!(code_owners.is_owned_by(&root.join("docs/README.md"), "@dev-team"));
+
+        // Test directory ownership
+        assert!(code_owners.is_owned_by(&root.join("src/"), "@dev-team"));
+        assert!(!code_owners.is_owned_by(&root.join("src/"), "@docs-team"));
+    }
+
+    #[test]
+    fn test_is_owned() {
+        let codeowners_content = r#"
+/src/ @dev-team
+/docs/ @docs-team
+/tests/
+        "#;
+
+        let (temp_dir, codeowners_path) = setup_test_dir(codeowners_content);
+        let root = temp_dir.path().to_path_buf();
+
+        let code_owners = CodeOwners::parse_from_file(&codeowners_path, &root).unwrap();
+
+        // Test if files are owned by any team
+        assert!(code_owners.is_owned(&root.join("src/main.rs")));
+        assert!(code_owners.is_owned(&root.join("docs/README.md")));
+
+        // Tests directory is ignored, so it should not be owned
+        assert!(!code_owners.is_owned(&root.join("tests")));
+    }
+
+    #[test]
+    fn test_lookup() {
+        let codeowners_content = r#"
+/src/ @dev-team
+/docs/ @docs-team @dev-team
+/tests/
+        "#;
+
+        let (temp_dir, codeowners_path) = setup_test_dir(codeowners_content);
+        let root = temp_dir.path().to_path_buf();
+
+        let code_owners = CodeOwners::parse_from_file(&codeowners_path, &root).unwrap();
+
+        // Test lookup for files
+        let src_owners = code_owners.lookup(&root.join("src/main.rs"));
+        assert_eq!(src_owners.len(), 1);
+        assert!(src_owners.contains(&"@dev-team".to_string()));
+
+        let docs_owners = code_owners.lookup(&root.join("docs/README.md"));
+        assert_eq!(docs_owners.len(), 2);
+        assert!(docs_owners.contains(&"@docs-team".to_string()));
+        assert!(docs_owners.contains(&"@dev-team".to_string()));
+
+        // Test lookup for directories
+        let src_dir_owners = code_owners.lookup(&root.join("src/"));
+        assert_eq!(src_dir_owners.len(), 1);
+        assert!(src_dir_owners.contains(&"@dev-team".to_string()));
+    }
+
+    #[test]
+    fn test_complex_patterns() {
+        let codeowners_content = r#"
+# Root files
+/**/*.md @docs-team
+
+# Source code
+/src/*.rs @dev-team
+/src/api/ @api-team
+/src/ui/ @ui-team
+
+# Documentation with multiple owners
+/docs/ @docs-team @dev-team
+
+# External libraries
+/lib/ @dev-team @sec-team
+
+# Tests with no explicit owner
+/tests/
+        "#;
+
+        let (temp_dir, codeowners_path) = setup_test_dir(codeowners_content);
+        let root = temp_dir.path().to_path_buf();
+
+        // Create additional directories and files for testing
+        let src_api_dir = root.join("src/api");
+        let src_ui_dir = root.join("src/ui");
+        let lib_dir = root.join("lib");
+
+        fs::create_dir_all(&src_api_dir).expect("Failed to create src/api directory");
+        fs::create_dir_all(&src_ui_dir).expect("Failed to create src/ui directory");
+        fs::create_dir_all(&lib_dir).expect("Failed to create lib directory");
+
+        File::create(root.join("README.md")).expect("Failed to create README.md");
+        File::create(src_api_dir.join("api.rs")).expect("Failed to create api.rs");
+        File::create(src_ui_dir.join("ui.rs")).expect("Failed to create ui.rs");
+        File::create(lib_dir.join("external.rs")).expect("Failed to create external.rs");
+
+        let code_owners = CodeOwners::parse_from_file(&codeowners_path, &root).unwrap();
+
+        // Test root markdown files
+        let readme_owners = code_owners.lookup(&root.join("README.md"));
+        assert_eq!(readme_owners.len(), 1);
+        assert!(readme_owners.contains(&"@docs-team".to_string()));
+
+        // Test src files
+        let main_owners = code_owners.lookup(&root.join("src/main.rs"));
+        assert_eq!(main_owners.len(), 1);
+        assert!(main_owners.contains(&"@dev-team".to_string()));
+
+        // Test api files
+        let api_owners = code_owners.lookup(&root.join("src/api/api.rs"));
+        assert_eq!(api_owners.len(), 2);
+        assert!(api_owners.contains(&"@api-team".to_string()));
+        assert!(api_owners.contains(&"@dev-team".to_string()));
+
+        // Test ui files
+        let ui_owners = code_owners.lookup(&root.join("src/ui/ui.rs"));
+        assert_eq!(ui_owners.len(), 2);
+        assert!(ui_owners.contains(&"@ui-team".to_string()));
+        assert!(ui_owners.contains(&"@dev-team".to_string()));
+
+        // Test lib files
+        let lib_owners = code_owners.lookup(&root.join("lib/external.rs"));
+        assert_eq!(lib_owners.len(), 2);
+        assert!(lib_owners.contains(&"@sec-team".to_string()));
+        assert!(lib_owners.contains(&"@dev-team".to_string()));
+    }
+}

--- a/crates/teamsearch_workspace/src/codeowners.rs
+++ b/crates/teamsearch_workspace/src/codeowners.rs
@@ -72,6 +72,7 @@ impl CodeOwners {
         } else {
             path.to_string_lossy().to_string()
         };
+        let mut owners = vec![];
 
         for owner in self.owners.keys() {
             // @@Todo: we could potentially use a `OnceCell` here to cache the
@@ -79,11 +80,11 @@ impl CodeOwners {
             let set = self.get_pattern_for_team(owner);
 
             if set.is_match(&path_pat) {
-                return Some(owner.to_string());
+                owners.push(owner.clone());
             }
         }
 
-        None
+        owners
     }
 
     /// Get all patterns for a specific team.


### PR DESCRIPTION
- **Expand `lookup` to list all codeowner teams for an entry**
- **Make orphans collector chain more readable**
- **Simplify path matching in `CODEOWNERS`**
- **Add comprehensive test suite for `CodeOwners`**
