### PR TITLE
Simplify path matching algorithm

### DIFF
--- a/crates/teamsearch/src/commands/find.rs
+++ b/crates/teamsearch/src/commands/find.rs
@@ -37,9 +37,10 @@ pub(crate) fn find(
         return Ok(FindResult::default());
     }
 
+    let root = fs::common_root(&paths);
+
     // We've gotta parse in the `CODEOWNERS` file, and then
     // extract the given patterns that are specified for the particular team.
-    let root = fs::common_root(&paths);
     let codeowners = CodeOwners::parse_from_file(&settings.codeowners, &root)?;
     let teams = team.iter().filter(|t| codeowners.has_team(t)).unique().collect::<Vec<_>>();
 
@@ -65,7 +66,7 @@ pub(crate) fn find(
 
     // Firstly, we need to discover all of the files in the provided paths.
     let files = timed(
-        || find_files_in_paths(files, &settings),
+        || find_files_in_paths(&root, files, &settings),
         log::Level::Debug,
         |duration, result| {
             debug!("resolved {} files in {:?}", result.as_ref().map_or(0, |f| f.len()), duration)

--- a/crates/teamsearch/src/commands/orphans.rs
+++ b/crates/teamsearch/src/commands/orphans.rs
@@ -45,7 +45,7 @@ pub fn orphans(
         settings.file_resolver.include.extend(vec![FilePattern::all()])?;
 
     let all_files =
-        find_files_in_paths(files, &settings)?.into_iter().collect::<Result<Vec<_>, _>>()?;
+        find_files_in_paths(&root, files, &settings)?.into_iter().collect::<Result<Vec<_>, _>>()?;
 
     // Depending on whether we have a small number of files, we can either
     // use a thread pool or not. Typically, for small numbers of files, we

--- a/crates/teamsearch_workspace/src/codeowners.rs
+++ b/crates/teamsearch_workspace/src/codeowners.rs
@@ -92,7 +92,6 @@ impl CodeOwners {
     /// "/"
     /// Helper method to format path for matching
     /// - Ensures directories end with "/"
-    /// - Ensures paths start with "/"
     fn format_path_for_matching(&self, path: &Path) -> String {
         // Convert path to string
         let mut path_str = path.to_string_lossy().to_string();
@@ -100,11 +99,6 @@ impl CodeOwners {
         // Ensure directories end with "/"
         if path.is_dir() && !path_str.ends_with('/') {
             path_str = format!("{}/", path_str);
-        }
-
-        // Ensure paths start with "/"
-        if !path_str.starts_with('/') {
-            path_str = format!("/{}", path_str);
         }
 
         path_str
@@ -166,6 +160,11 @@ impl CodeOwners {
 
             let convert_to_user = |path: &str| {
                 let mut buf = path.to_owned();
+
+                // if the path starts with a `/`, we need to remove it.
+                if buf.starts_with('/') {
+                    buf = buf[1..].to_string();
+                }
 
                 if buf.ends_with('/') {
                     buf.push_str("**");


### PR DESCRIPTION
When loading the codeowners file, avoid keeping track of the `/`
prefix on paths.

Similarly, when scanning for paths, we always strip the base path
`prefix` from the path before matching.

This means that we can both simplify the regex matching, and
avoid having to inject `/` prefixes in the regexes when scanning
for paths across the workspace.
