### PR TITLE
Refactor find command output to ripgrep-style format with colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,28 +49,13 @@ The `find` command is useful when you want to search for code based on a specifi
 teamsearch find . -c .github/CODEOWNERS -t "my-team" -p "c(o)+de"
 ```
 
-```py
-info: match found
-  --> repo/sub/item3.html:2:11
-   |
- 2 |     const code = {
-   |           ----
-   |
-  ::: repo/sub/item3.html:3:15
-   |
- 3 |         "some-cooode-pattern": "some-value",
-   |               ------
-   |
-  ::: repo/sub/item3.html:4:18
-   |
- 4 |         "another-code-pattern": "some-value",
-   |                  ----
-   |
-  ::: repo/sub/item3.html:10:40
-   |
-10 |     <p>Hello world, a fast way to find code owned by teams</p>
-   |                                        ----
-   |
+```
+repo/sub/item3.html
+2:    const code = {
+3:        "some-cooode-pattern": "some-value",
+4:        "another-code-pattern": "some-value",
+10:    <p>Hello world, a fast way to find code owned by teams</p>
+
 info: found 4 matches in 7.918375ms
 ```
 

--- a/crates/teamsearch_utils/src/lib.rs
+++ b/crates/teamsearch_utils/src/lib.rs
@@ -1,6 +1,7 @@
 //! Various `teamsearch` utilities.
 pub mod fs;
 pub mod highlight;
+pub mod lines;
 pub mod logging;
 pub mod stream;
 pub mod thread_pool;

--- a/crates/teamsearch_utils/src/lines.rs
+++ b/crates/teamsearch_utils/src/lines.rs
@@ -1,0 +1,21 @@
+/// Get the line number (1-indexed) and byte range for a given byte position.
+///
+/// Returns a tuple of (line_number, line_start_byte, line_end_byte) where
+/// line_number is 1-indexed.
+pub fn get_line_range(contents: &str, byte_pos: usize) -> (usize, usize, usize) {
+    // Count newlines before the position to get the line number.
+    // Line numbers are 1-indexed, so we add 1.
+    let line_num = contents[..byte_pos].bytes().filter(|&b| b == b'\n').count() + 1;
+
+    // Find the start and end of the line containing this byte position.
+    let line_start = if line_num == 1 {
+        0
+    } else {
+        contents[..byte_pos].rfind('\n').map(|pos| pos + 1).unwrap_or(0)
+    };
+
+    let line_end =
+        contents[byte_pos..].find('\n').map(|offset| byte_pos + offset).unwrap_or(contents.len());
+
+    (line_num, line_start, line_end)
+}


### PR DESCRIPTION
This PR refactors the `find` command output to match ripgrep's familiar format, making results more compact.

## Changes

- **Output format**: Changed from styled snippet annotations to ripgrep-style grouped-by-file format
- **Color coding**: Added terminal colors matching ripgrep's color scheme:
  - File paths in magenta/pink
  - Line numbers in bright green  
  - Matched text highlighted in red
- **Grouping**: Results are now grouped by file, with all matches for a file shown together

## Before
<img width="1680" height="1584" alt="CleanShot 2025-10-31 at 15 14 02@2x" src="https://github.com/user-attachments/assets/487893ae-4703-4912-bad7-2f4d2c1809bf" />

## After 

<img width="1656" height="978" alt="CleanShot 2025-11-01 at 14 39 58@2x" src="https://github.com/user-attachments/assets/d9f25dbc-6504-403f-b80b-8e503ceaa2aa" />

