### PR TITLE
Migrate to `stable` Rust channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
@@ -21,15 +20,14 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
-          components: rustfmt
-
+          toolchain: stable
+          components: rustfmt, clippy
 
       - name: Dependency caching
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates
-      
+
       - name: Run tests
         run: "cargo test --all --verbose"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
-members = [
-  "crates/teamsearch*",
-]
+members = ["crates/teamsearch*"]
 
 resolver = "2"
 
@@ -51,4 +49,4 @@ debug = false
 [profile.release-with-dbg-info]
 inherits = "release"
 debug = true
-strip = false  # You'll want to disable stripping to keep debug symbols
+strip = false        # You'll want to disable stripping to keep debug symbols

--- a/crates/teamsearch/src/lib.rs
+++ b/crates/teamsearch/src/lib.rs
@@ -1,7 +1,5 @@
 //! Library definition of `teamsearch` crate.
 
-#![feature(panic_payload_as_str)]
-
 pub mod cli;
 mod commands;
 mod crash;

--- a/crates/teamsearch_matcher/src/lib.rs
+++ b/crates/teamsearch_matcher/src/lib.rs
@@ -77,7 +77,7 @@ impl FileMatches {
         self.matches.is_empty()
     }
 
-    fn snippets(&self) -> Vec<MatchSnippet> {
+    fn snippets(&self) -> Vec<MatchSnippet<'_>> {
         self.matches
             .iter()
             .map(|m| MatchSnippet {

--- a/crates/teamsearch_workspace/src/codeowners.rs
+++ b/crates/teamsearch_workspace/src/codeowners.rs
@@ -128,7 +128,7 @@ impl CodeOwners {
     /// Example: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
     ///
     /// ```plaintext
-    /// 
+    ///
     /// # This is a comment.
     ///
     /// # The owners of the root directory.

--- a/crates/teamsearch_workspace/src/resolver.rs
+++ b/crates/teamsearch_workspace/src/resolver.rs
@@ -145,36 +145,36 @@ pub struct FilesVisitor<'s, 'config> {
 impl ignore::ParallelVisitor for FilesVisitor<'_, '_> {
     fn visit(&mut self, result: Result<DirEntry, Error>) -> WalkState {
         // Respect our own exclusion behaviour.
-        if let Ok(entry) = &result {
-            if entry.depth() > 0 {
-                let path = entry.path().strip_prefix(self.base).unwrap();
-                let resolver = self.global.resolver.read().unwrap();
-                let settings = resolver.resolve(path);
+        if let Ok(entry) = &result
+            && entry.depth() > 0
+        {
+            let path = entry.path().strip_prefix(self.base).unwrap();
+            let resolver = self.global.resolver.read().unwrap();
+            let settings = resolver.resolve(path);
 
-                if let Some(file_name) = path.file_name() {
-                    let file_path = Candidate::new(path);
-                    let file_basename = Candidate::new(file_name);
+            if let Some(file_name) = path.file_name() {
+                let file_path = Candidate::new(path);
+                let file_basename = Candidate::new(file_name);
 
-                    if match_candidate_exclusion(
-                        &file_path,
-                        &file_basename,
-                        &settings.file_resolver.exclude,
-                    ) {
-                        return WalkState::Skip;
-                    }
-
-                    // @@Todo: we should combine `exclude` and `user_exclude` into a single
-                    // exclusion set.
-                    if match_candidate_exclusion(
-                        &file_path,
-                        &file_basename,
-                        &settings.file_resolver.user_exclude,
-                    ) {
-                        return WalkState::Skip;
-                    }
-                } else {
+                if match_candidate_exclusion(
+                    &file_path,
+                    &file_basename,
+                    &settings.file_resolver.exclude,
+                ) {
                     return WalkState::Skip;
                 }
+
+                // @@Todo: we should combine `exclude` and `user_exclude` into a single
+                // exclusion set.
+                if match_candidate_exclusion(
+                    &file_path,
+                    &file_basename,
+                    &settings.file_resolver.user_exclude,
+                ) {
+                    return WalkState::Skip;
+                }
+            } else {
+                return WalkState::Skip;
             }
         }
 

--- a/crates/teamsearch_workspace/src/settings.rs
+++ b/crates/teamsearch_workspace/src/settings.rs
@@ -38,10 +38,14 @@ impl FilePattern {
 
 impl fmt::Display for FilePattern {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", match self {
-            Self::Builtin(pattern) => pattern,
-            Self::User(pattern) => pattern.as_str(),
-        })
+        write!(
+            f,
+            "{:?}",
+            match self {
+                Self::Builtin(pattern) => pattern,
+                Self::User(pattern) => pattern.as_str(),
+            }
+        )
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-01-05"
+channel = "stable"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,2 @@
 use_small_heuristics = "Max"
-format_code_in_doc_comments = true
-wrap_comments = true
-imports_granularity = "Crate"
 use_field_init_shorthand = true
-group_imports = "StdExternalCrate"


### PR DESCRIPTION
This PR changes the `teamsearch` Rust toolchain channel to stable.

Along with this channel change, we update the existing implementation
to depend on any nightly features.
