### PR TITLE
fix(auto-assign): pass --repo to gh pr edit

### DIFF
--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -11,6 +11,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Request review from feds01
-        run: gh pr edit ${{ github.event.pull_request.number }} --add-reviewer feds01
+        run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-reviewer feds01
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix broken auto-assign workflow. `gh pr edit` tries to infer target repo from git remote, but the workflow has no checkout step. Pass `--repo \${{ github.repository }}` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)